### PR TITLE
Remove warnings in Elixir 1.16

### DIFF
--- a/lib/stemmer/step1b.ex
+++ b/lib/stemmer/step1b.ex
@@ -93,9 +93,15 @@ defmodule Stemmer.Step1b do
   defp post_remove_ed_edly_ing_ingly(word) do
     cond do
       String.ends_with?(word, ~w(at bl iz)) -> word <> "e"
-      String.ends_with?(word, Rules.doubles()) -> String.slice(word, 0..-2//1)
+      String.ends_with?(word, Rules.doubles()) -> String.slice(word, range_to_end(-2))
       Rules.short?(word) -> word <> "e"
       true -> word
     end
+  end
+
+  if Version.match?(System.version(), ">= 1.16.0") do
+    defp range_to_end(offset), do: Range.new(0, offset, 1)
+  else
+    defp range_to_end(offset), do: (0..offset)
   end
 end

--- a/lib/stemmer/step1b.ex
+++ b/lib/stemmer/step1b.ex
@@ -93,7 +93,7 @@ defmodule Stemmer.Step1b do
   defp post_remove_ed_edly_ing_ingly(word) do
     cond do
       String.ends_with?(word, ~w(at bl iz)) -> word <> "e"
-      String.ends_with?(word, Rules.doubles()) -> String.slice(word, 0..-2)
+      String.ends_with?(word, Rules.doubles()) -> String.slice(word, 0..-2//1)
       Rules.short?(word) -> word <> "e"
       true -> word
     end

--- a/mix.lock
+++ b/mix.lock
@@ -13,6 +13,6 @@
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.0", "b44d75e2a6542dcb6acf5d71c32c74ca88960421b6874777f79153bbbbd7dccc", [:mix], [], "hexpm", "52b2871a7515a5ac49b00f214e4165a40724cf99798d8e4a65e4fd64ebd002c1"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }


### PR DESCRIPTION
Elixir 1.16 added runtime warnings for implicit negative steps in ranges.

`String.slice("some string", 0..-2)` complains in logs when used

```
warning: negative steps are not supported in String.slice/2, pass 0..-2//1 instead
```

The suggested fix however is not possible for older versions of Elixir -- so this is a backwards-compatible change that should work on older versions of Elixir.

I've executed the test suite on Elixir 1.11 and Elixir 1.16 to confirm the changes are working.